### PR TITLE
Set up continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,5 +49,5 @@ install:
 - pip install -e .
 script:
 - pip install -r requirements-testing.txt
-- pytest --cov=exconfig --cov-report=xml:$(pwd)/coverage.xml --run-notebook -vvv
+- pytest --cov=exconfig --cov-report=xml:$(pwd)/coverage.xml -vvv
 after_success: coveralls

--- a/README.rst
+++ b/README.rst
@@ -1,2 +1,62 @@
-# exconfig
-Create and configure input parameter files
+====================================================
+exconfig: Create and configure input parameter files
+====================================================
+
+.. image:: https://img.shields.io/travis/mcflugen/exconfig.svg
+        :target: https://travis-ci.org/mcflugen/exconfig
+
+.. image:: https://ci.appveyor.com/api/projects/status/380ox1dv8hekefq9?svg=true
+    :target: https://ci.appveyor.com/project/mcflugen/exconfig/branch/master
+
+.. image:: https://readthedocs.org/projects/exconfig/badge/?version=latest
+        :target: https://exconfig.readthedocs.io/en/latest/?badge=latest
+        :alt: Documentation Status
+
+About
+-----
+
+*exconfig* is a Python library for working with input parameter files. It
+provides parameter description and validation, as well as ways of working
+with various file formats.
+
+
+Requirements
+------------
+
+*exonfig* requires Python 3.
+
+Apart from Python, *exconfig* has a number of other requirements, all of which
+can be obtained through either *pip* or *conda*, that will be automatically
+installed when you install *exconfig*.
+
+To see a full listing of the requirements, have a look at the project's
+*requirements.txt* file.
+
+If you are a developer of *exconfig* you will also want to install
+additional dependencies for running *exconfig*'s tests to make sure
+that things are working as they should. These dependencies are listed
+in *requirements-testing.txt*.
+
+Installation
+------------
+
+Stable Release
+++++++++++++++
+
+*exconfig*, and its dependencies, can be installed either with *pip*
+or *conda*. Using *pip*::
+
+    $ pip install exconfig
+
+Using *conda*::
+
+    $ conda install exconfig -c conda-forge
+
+From Source
++++++++++++
+
+After downloading the *exconfig* source code, run the following from
+*exconfig*'s top-level folder (the one that contains *setup.py*) to
+install *exconfig* into the current environment::
+
+  $ pip install -e .

--- a/exconfig/__init__.py
+++ b/exconfig/__init__.py
@@ -10,7 +10,7 @@ from .field import (
     IntegerField,
 )
 
-__all__ = ["Configuration", "validators", "ValidationError"]
+__all__ = ["Configuration", "validators", "ValidationError", "ArrayField", "BooleanField", "FloatField", "IntegerField", "ConfigurationField"]
 
 __version__ = get_versions()["version"]
 del get_versions

--- a/exconfig/__init__.py
+++ b/exconfig/__init__.py
@@ -10,7 +10,16 @@ from .field import (
     IntegerField,
 )
 
-__all__ = ["Configuration", "validators", "ValidationError", "ArrayField", "BooleanField", "FloatField", "IntegerField", "ConfigurationField"]
+__all__ = [
+    "ArrayField",
+    "BooleanField",
+    "Configuration",
+    "ConfigurationField",
+    "FloatField",
+    "IntegerField",
+    "ValidationError",
+    "validators",
+]
 
 __version__ = get_versions()["version"]
 del get_versions

--- a/exconfig/configuration.py
+++ b/exconfig/configuration.py
@@ -1,14 +1,9 @@
 import os
 import sys
-import textwrap
 
 import ruamel.yaml
 import yaml
 from ruamel.yaml.comments import CommentedMap
-
-from .errors import ValidationError
-from .field import ArrayField, ConfigurationField, FloatField, IntegerField
-from .validators import Length, Range
 
 
 class ConfigurationBase:

--- a/exconfig/field.py
+++ b/exconfig/field.py
@@ -1,4 +1,3 @@
-import itertools
 import os
 import pathlib
 import textwrap
@@ -17,7 +16,7 @@ class UnboundField:
         self.args = args
         self.kwargs = kwargs
         self.creation_counter = UnboundField.creation_counter
-        validators = kwargs.get("validators")
+        # validators = kwargs.get("validators")
         # if validators:
         #     self.field_class.check_validators(validators)
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,5 +1,3 @@
-import os
-
 import pytest
 
 from exconfig import ValidationError


### PR DESCRIPTION
This pull request sets up continuous integration on Travis and AppVeyor. Tests are run for Python 3.6, 2.7, and 3.8 on Linux, Mac, and Window. To test the deployment stage, I also created a v0.1 tag that has been deployed to [PyPI](https://pypi.org/project/exconfig/).