### PR TITLE
Allow exists keyword to be None

### DIFF
--- a/exconfig/__init__.py
+++ b/exconfig/__init__.py
@@ -6,6 +6,7 @@ from .field import (
     ArrayField,
     BooleanField,
     ConfigurationField,
+    Field,
     FloatField,
     IntegerField,
 )
@@ -15,6 +16,7 @@ __all__ = [
     "BooleanField",
     "Configuration",
     "ConfigurationField",
+    "Field",
     "FloatField",
     "IntegerField",
     "ValidationError",


### PR DESCRIPTION
This pull request changes the *Path* validator to accept a value of `None` for the *exists* keyword. A value of `None` means that the validator doesn't have an opinion on whether or not the file or folder already exists.